### PR TITLE
Fix "Undefined offset: 0" error

### DIFF
--- a/yqfk.py
+++ b/yqfk.py
@@ -48,6 +48,8 @@ def post_form(message, target):
     yqfk_session.get(url=yqfk_acesstoken.url)
     yqfk_info = yqfk_session.get('http://yqfk.dgut.edu.cn/home/base_info/getBaseInfo', headers=headers_2).json()
     yqfk_json = yqfk_info['info']
+    yqfk_json['important_area'] = None
+    yqfk_json['current_region'] = None
 
     console_msg(yqfk_info['message'])
     message.append(yqfk_info['message'])


### PR DESCRIPTION
Infos got from `getBaseInfo`:

```json
"important_area": [],
"current_region": []
```

Infos posted to `addBaseInfo`:

```json
"important_area": null,
"current_region": null
```

I think this is the cause of the `Undefined offset: 0` PHP error.

